### PR TITLE
🛡️ Sentinel: [CRITICAL] Fix Information Disclosure via var_dump

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,5 @@
+## 2024-05-06 - Sentinel Journal
+
+**Vulnerability:** Information Disclosure via Error Messages (`var_dump($config)`)
+**Learning:** In PHP, `var_dump()` is often used for debugging, but if left in production code (especially error handling paths), it can expose sensitive variables to users or attackers. In this case, it was dumping the `$config` variable, which contains sensitive database credentials, AWS keys, and email passwords when a validation error occurs.
+**Prevention:** Always review debugging statements like `var_dump()`, `print_r()`, or `console.log()` before committing. Error messages should be generic and not leak internal state or configuration.

--- a/www80/public/index.php
+++ b/www80/public/index.php
@@ -81,7 +81,7 @@ if( count($validation) > 0 ) {
 
      echo "<pre>";
      echo join("\n", $validation);
-     var_dump($config);
+
      echo "</pre>";
      exit(1);
 }


### PR DESCRIPTION
🚨 Severity: CRITICAL
💡 Vulnerability: The application was leaking sensitive configuration details via `var_dump($config)` when configuration validation failed.
🎯 Impact: Attackers could gain access to database credentials, AWS keys, and email passwords.
🔧 Fix: Removed the `var_dump()` call from the error response.
✅ Verification: Ran `php -l www80/public/index.php` to verify syntax.

---
*PR created automatically by Jules for task [16767396476296638232](https://jules.google.com/task/16767396476296638232) started by @ricardoapaes*